### PR TITLE
Add settings modal for OpenAI embeddings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+langchain-openai
+streamlit_js_eval

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -80,7 +80,20 @@ api_key = st.session_state.openai_api_key
 if is_valid_openai_api_key(api_key):
     embedder = OpenAIEmbeddings(
         model="text-embedding-3-small", openai_api_key=api_key
-    )
+model_name = "text-embedding-3-small"
+if api_key:
+    # Cache the embedder in session_state to avoid recreating it unnecessarily
+    if (
+        "embedder" not in st.session_state
+        or st.session_state.get("embedder_api_key") != api_key
+        or st.session_state.get("embedder_model") != model_name
+    ):
+        st.session_state.embedder = OpenAIEmbeddings(
+            model=model_name, openai_api_key=api_key
+        )
+        st.session_state.embedder_api_key = api_key
+        st.session_state.embedder_model = model_name
+    embedder = st.session_state.embedder
 
 @st.cache_data(show_spinner="Generating embedding...")
 def get_hello_world_embedding(api_key: str):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -26,7 +26,7 @@ def load_api_key() -> str:
 def save_api_key(key: str) -> None:
     """Persist the API key to local storage."""
     streamlit_js_eval(
-        js_expressions=f"localStorage.setItem('openai_api_key', '{key}')",
+        js_expressions=f"localStorage.setItem('openai_api_key', {json.dumps(key)})",
         key="set_api_key",
     )
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -65,7 +65,19 @@ if st.session_state.get("show_settings"):
 
 
 api_key = st.session_state.openai_api_key
-if api_key:
+                input_key = st.session_state.api_key_input
+                if is_valid_openai_api_key(input_key):
+                    st.session_state.openai_api_key = input_key
+                    save_api_key(input_key)
+                    close_settings()
+                else:
+                    st.error("Invalid API key format. Please enter a valid OpenAI API key (starts with 'sk-' and is the correct length).")
+        with col_close:
+            st.button("Close", on_click=close_settings)
+
+
+api_key = st.session_state.openai_api_key
+if is_valid_openai_api_key(api_key):
     embedder = OpenAIEmbeddings(
         model="text-embedding-3-small", openai_api_key=api_key
     )

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,4 +1,75 @@
+"""Streamlit app demonstrating OpenAI embeddings via LangChain.
+
+The app provides a settings modal where users can supply an OpenAI API
+key. The key is persisted in the browser's local storage so it only needs
+to be entered once. When a key is available an example embedding for
+"Hello world" is generated and displayed.
+"""
+
 import streamlit as st
+from langchain_openai import OpenAIEmbeddings
+from streamlit_js_eval import streamlit_js_eval
+
 
 st.title("Hello, World!")
-# hey
+
+
+def load_api_key() -> str:
+    """Retrieve the stored API key from local storage."""
+    api_key = streamlit_js_eval(
+        js_expressions="localStorage.getItem('openai_api_key')",
+        key="get_api_key",
+    )
+    return api_key or ""
+
+
+def save_api_key(key: str) -> None:
+    """Persist the API key to local storage."""
+    streamlit_js_eval(
+        js_expressions=f"localStorage.setItem('openai_api_key', '{key}')",
+        key="set_api_key",
+    )
+
+
+if "openai_api_key" not in st.session_state:
+    st.session_state.openai_api_key = load_api_key()
+
+
+def open_settings() -> None:
+    st.session_state.show_settings = True
+
+
+def close_settings() -> None:
+    st.session_state.show_settings = False
+
+
+st.button("Settings", on_click=open_settings)
+
+if st.session_state.get("show_settings"):
+    with st.modal("Settings"):
+        st.text_input(
+            "OpenAI API Key",
+            value=st.session_state.openai_api_key,
+            key="api_key_input",
+            type="password",
+        )
+
+        col_save, col_close = st.columns(2)
+        with col_save:
+            if st.button("Save"):
+                st.session_state.openai_api_key = st.session_state.api_key_input
+                save_api_key(st.session_state.api_key_input)
+                close_settings()
+        with col_close:
+            st.button("Close", on_click=close_settings)
+
+
+api_key = st.session_state.openai_api_key
+if api_key:
+    embedder = OpenAIEmbeddings(
+        model="text-embedding-3-small", openai_api_key=api_key
+    )
+    vector = embedder.embed_query("Hello world")
+    st.write(vector)
+else:
+    st.info("Set your OpenAI API key in settings to generate embeddings.")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -69,7 +69,16 @@ if api_key:
     embedder = OpenAIEmbeddings(
         model="text-embedding-3-small", openai_api_key=api_key
     )
-    vector = embedder.embed_query("Hello world")
+
+@st.cache_data(show_spinner="Generating embedding...")
+def get_hello_world_embedding(api_key: str):
+    embedder = OpenAIEmbeddings(
+        model="text-embedding-3-small", openai_api_key=api_key
+    )
+    return embedder.embed_query("Hello world")
+
+if api_key:
+    vector = get_hello_world_embedding(api_key)
     st.write(vector)
 else:
     st.info("Set your OpenAI API key in settings to generate embeddings.")


### PR DESCRIPTION
## Summary
- Add Streamlit settings modal to capture and persist OpenAI API key
- Integrate LangChain OpenAIEmbeddings for example embedding
- Provide requirements file with necessary dependencies

## Testing
- `python -m py_compile streamlit_app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68a8a2dfc5f88323be4c0143e6812702