### PR TITLE
Provide Streamlit modal fallback

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -52,7 +52,11 @@ def close_settings() -> None:
 st.button("Settings", on_click=open_settings)
 
 if st.session_state.get("show_settings"):
-    with st.modal("Settings"):
+    has_modal = hasattr(st, "modal")
+    container = st.modal("Settings") if has_modal else st.sidebar
+    with container:
+        if not has_modal:
+            st.header("Settings")
         api_key_input = st.text_input(
             "OpenAI API Key",
             value=st.session_state.openai_api_key,


### PR DESCRIPTION
## Summary
- Avoid AttributeError when `st.modal` is unavailable by falling back to `st.sidebar` for settings UI.

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a930728c94832390a3a68602679d56