### PR TITLE
Add clustering utility for embedding analysis

### DIFF
--- a/clustering.py
+++ b/clustering.py
@@ -1,0 +1,83 @@
+"""Utility for clustering high-dimensional embeddings and visualizing the results.
+
+This module provides a helper to cluster embedding vectors using different
+scikit-learn algorithms and display the clusters using t-SNE for dimensionality
+reduction.
+"""
+
+from typing import Iterable, Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.cluster import AgglomerativeClustering, DBSCAN, KMeans
+from sklearn.manifold import TSNE
+
+# Mapping of algorithm names to their constructors. Functions accept the desired
+# number of clusters and return an instantiated estimator.
+CLUSTERERS = {
+    "kmeans": lambda n: KMeans(n_clusters=n, random_state=42),
+    "agglomerative": lambda n: AgglomerativeClustering(n_clusters=n),
+    "dbscan": lambda _: DBSCAN(),
+}
+
+
+def cluster_embeddings(
+    embeddings: np.ndarray,
+    algorithm: str = "kmeans",
+    n_clusters: int = 3,
+) -> np.ndarray:
+    """Cluster embedding vectors using the selected algorithm.
+
+    Parameters
+    ----------
+    embeddings:
+        Array of shape (n_samples, n_features) containing the embeddings.
+    algorithm:
+        Name of the clustering algorithm to use. Options are ``"kmeans"``,
+        ``"agglomerative"``, and ``"dbscan"``.
+    n_clusters:
+        Number of clusters for algorithms that require it.
+
+    Returns
+    -------
+    np.ndarray
+        The cluster label for each embedding.
+    """
+    algorithm = algorithm.lower()
+    if algorithm not in CLUSTERERS:
+        raise ValueError(f"Unsupported algorithm: {algorithm}")
+
+    clusterer = CLUSTERERS[algorithm](n_clusters)
+    labels = clusterer.fit_predict(embeddings)
+    return labels
+
+
+def visualize_clusters(
+    embeddings: np.ndarray,
+    labels: Iterable[int],
+    title: Optional[str] = None,
+) -> plt.Figure:
+    """Create a t-SNE scatter plot of clustered embeddings.
+
+    The returned matplotlib figure can be rendered in different contexts,
+    such as Streamlit via ``st.pyplot``.
+    """
+    reduced = TSNE(n_components=2, random_state=42).fit_transform(embeddings)
+    fig, ax = plt.subplots()
+    ax.scatter(reduced[:, 0], reduced[:, 1], c=labels, cmap="tab10")
+    ax.set_xlabel("TSNE-1")
+    ax.set_ylabel("TSNE-2")
+    ax.set_title(title or "Embedding clusters")
+    fig.tight_layout()
+    return fig
+
+
+if __name__ == "__main__":
+    # Example usage with the Iris dataset.
+    from sklearn.datasets import load_iris
+
+    iris = load_iris()
+    data = iris.data
+    labels = cluster_embeddings(data, algorithm="kmeans", n_clusters=3)
+    fig = visualize_clusters(data, labels, title="KMeans clustering of Iris data")
+    fig.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 streamlit
 langchain-openai
 streamlit_js_eval
+scikit-learn
+matplotlib

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -7,9 +7,11 @@ generated and displayed.
 """
 
 import json
+import numpy as np
 import streamlit as st
 from langchain_openai import OpenAIEmbeddings
 from streamlit_js_eval import streamlit_js_eval
+from clustering import cluster_embeddings, visualize_clusters
 
 
 st.title("Hello, World!")
@@ -103,17 +105,46 @@ if api_key:
         st.session_state.embedder_model = model_name
     embedder = st.session_state.embedder
 
+    if "prompts" not in st.session_state:
+        st.session_state.prompts = []
+    if "embeddings" not in st.session_state:
+        st.session_state.embeddings = []
+
     prompt = st.text_area("System Prompt")
 
     @st.cache_data(show_spinner="Generating embedding...")
     def get_embedding(text: str, api_key: str):
         return embedder.embed_query(text)
 
-    if st.button("Analyze"):
+    if st.button("Add to dataset"):
         if prompt.strip():
             vector = get_embedding(prompt, api_key)
-            st.write(vector)
+            st.session_state.prompts.append(prompt)
+            st.session_state.embeddings.append(vector)
+            st.success("Prompt added.")
         else:
             st.error("Please enter text to analyze.")
+
+    if st.session_state.prompts:
+        st.subheader("Current prompts")
+        for i, p in enumerate(st.session_state.prompts, 1):
+            st.write(f"{i}. {p}")
+
+    if len(st.session_state.embeddings) >= 2:
+        algorithm = st.selectbox(
+            "Clustering algorithm", ["kmeans", "agglomerative", "dbscan"], index=0
+        )
+        n_clusters = st.number_input(
+            "Number of clusters", min_value=2, max_value=10, value=3
+        )
+        if st.button("Visualize clusters"):
+            embeddings = np.array(st.session_state.embeddings)
+            labels = cluster_embeddings(
+                embeddings, algorithm=algorithm, n_clusters=int(n_clusters)
+            )
+            fig = visualize_clusters(embeddings, labels, title="Prompt clusters")
+            st.pyplot(fig)
+    else:
+        st.info("Add at least two prompts to visualize clusters.")
 else:
     st.info("Set your OpenAI API key in settings to generate embeddings.")


### PR DESCRIPTION
## Summary
- add clustering helper that supports KMeans, Agglomerative, and DBSCAN and visualizes results with t-SNE
- include example usage on the iris dataset
- update requirements with scikit-learn and matplotlib
- allow Streamlit app to build a dataset of prompts and visualize clusters using the helper

## Testing
- `python -m py_compile clustering.py streamlit_app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9718b87c483239173c6557621df83