### PR TITLE
Ensure t-SNE perplexity remains valid for tiny datasets

### DIFF
--- a/clustering.py
+++ b/clustering.py
@@ -60,8 +60,9 @@ def visualize_clusters(
     """Create a t-SNE scatter plot of clustered embeddings.
 
     The returned matplotlib figure can be rendered in different contexts,
-    such as Streamlit via ``st.pyplot``. Perplexity is adjusted to remain
-    valid for the number of provided samples.
+    such as Streamlit via ``st.pyplot``. The t-SNE ``perplexity`` parameter is
+    automatically clamped to keep it within ``(0, n_samples)`` so small
+    datasets do not trigger a ``ValueError`` during visualization.
     """
     n_samples = embeddings.shape[0]
     if n_samples < 2:

--- a/test_clustering.py
+++ b/test_clustering.py
@@ -1,0 +1,12 @@
+import numpy as np
+from matplotlib.figure import Figure
+
+from clustering import visualize_clusters
+
+
+def test_visualize_clusters_adjusts_perplexity():
+    """visualize_clusters should adapt t-SNE perplexity for tiny datasets."""
+    embeddings = np.array([[0.0, 0.0], [1.0, 1.0]])
+    labels = [0, 1]
+    fig = visualize_clusters(embeddings, labels)
+    assert isinstance(fig, Figure)


### PR DESCRIPTION
## Summary
- clarify that t-SNE perplexity is clamped to the valid range during visualization
- add regression test confirming visualize_clusters works with only two samples

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a97f987c788323869beadb33b730a0