### PR TITLE
Improve cluster visualization robustness

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -140,16 +140,20 @@ if api_key:
             except ValueError as err:
                 st.error(str(err))
             else:
-                fig = visualize_clusters(
-                    embeddings, labels, title="Sentence clusters"
-                )
-                st.pyplot(fig)
-                st.subheader("Clustered sentences")
-                sentences_arr = np.array(sentences)
-                for label in sorted(set(labels)):
-                    st.markdown(f"**Cluster {label}**")
-                    for sent in sentences_arr[labels == label]:
-                        st.write(sent)
+                try:
+                    fig = visualize_clusters(
+                        embeddings, labels, title="Sentence clusters"
+                    )
+                except ValueError as err:
+                    st.warning(str(err))
+                else:
+                    st.pyplot(fig)
+                    st.subheader("Clustered sentences")
+                    sentences_arr = np.array(sentences)
+                    for label in sorted(set(labels)):
+                        st.markdown(f"**Cluster {label}**")
+                        for sent in sentences_arr[labels == label]:
+                            st.write(sent)
         else:
             st.error("Please enter a system prompt to analyze.")
 else:

--- a/test_clustering.py
+++ b/test_clustering.py
@@ -4,9 +4,18 @@ from matplotlib.figure import Figure
 from clustering import visualize_clusters
 
 
-def test_visualize_clusters_adjusts_perplexity():
-    """visualize_clusters should adapt t-SNE perplexity for tiny datasets."""
+def test_visualize_clusters_uses_pca_for_small_datasets():
+    """visualize_clusters should fall back to PCA when samples are ≤3."""
     embeddings = np.array([[0.0, 0.0], [1.0, 1.0]])
     labels = [0, 1]
     fig = visualize_clusters(embeddings, labels)
     assert isinstance(fig, Figure)
+    assert "PCA" in fig.axes[0].get_title()
+
+
+def test_visualize_clusters_clamps_perplexity():
+    """t-SNE perplexity is clamped to ``n_samples - 1`` when too large."""
+    embeddings = np.array([[float(i), float(i)] for i in range(5)])
+    labels = [0, 1, 0, 1, 0]
+    fig = visualize_clusters(embeddings, labels)
+    assert "perp=4.0" in fig.axes[0].get_title()


### PR DESCRIPTION
## Summary
- Clamp t-SNE perplexity and fall back to PCA for very small datasets
- Handle NaN/Inf embeddings and warn through Streamlit instead of crashing
- Add tests for PCA fallback and perplexity clamping

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a98441082c83239880bd36e7b1bdc8