### PR TITLE
Replace t-SNE with PCA for cluster visualization

### DIFF
--- a/clustering.py
+++ b/clustering.py
@@ -1,7 +1,7 @@
 """Utility for clustering high-dimensional embeddings and visualizing the results.
 
 This module provides a helper to cluster embedding vectors using different
-scikit-learn algorithms and display the clusters using t-SNE for dimensionality
+scikit-learn algorithms and display the clusters using PCA for dimensionality
 reduction.
 """
 
@@ -11,7 +11,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 from sklearn.cluster import AgglomerativeClustering, DBSCAN, KMeans
 from sklearn.decomposition import PCA
-from sklearn.manifold import TSNE
 
 # Mapping of algorithm names to their constructors. Functions accept the desired
 # number of clusters and return an instantiated estimator.
@@ -57,10 +56,9 @@ def visualize_clusters(
     embeddings: np.ndarray,
     labels: Iterable[int],
     title: str = "Sentence clusters",
-    perplexity: float = 30.0,
     random_state: int = 42,
 ) -> plt.Figure:
-    """Visualize clustered embeddings using t-SNE or PCA.
+    """Visualize clustered embeddings using PCA.
 
     Parameters
     ----------
@@ -70,8 +68,6 @@ def visualize_clusters(
         Iterable of cluster labels for each embedding.
     title:
         Plot title. Defaults to ``"Sentence clusters"``.
-    perplexity:
-        Desired t-SNE perplexity. Values outside ``(0, n_samples)`` are clamped.
     random_state:
         Random seed for reproducible dimensionality reduction.
 
@@ -94,21 +90,9 @@ def visualize_clusters(
         if n_samples < 2:
             raise ValueError("Not enough valid samples after removing NaN/Inf rows.")
 
-    if n_samples <= 3:
-        reducer = PCA(n_components=2, random_state=random_state)
-        Y = reducer.fit_transform(X)
-        method = "PCA (n≤3)"
-    else:
-        effective_perplexity = min(float(perplexity), max(1.0, n_samples - 1.0))
-        reducer = TSNE(
-            n_components=2,
-            perplexity=effective_perplexity,
-            init="pca",
-            random_state=random_state,
-            learning_rate="auto",
-        )
-        Y = reducer.fit_transform(X)
-        method = f"t-SNE (perp={effective_perplexity:.1f}, n={n_samples})"
+    reducer = PCA(n_components=2, random_state=random_state)
+    Y = reducer.fit_transform(X)
+    method = "PCA"
 
     fig, ax = plt.subplots()
     ax.scatter(Y[:, 0], Y[:, 1], s=40)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -117,14 +117,6 @@ if api_key:
             "Number of clusters", min_value=2, max_value=10, value=3
         )
 
-    perplexity = st.number_input(
-        "t-SNE perplexity",
-        min_value=1.0,
-        max_value=100.0,
-        value=30.0,
-        step=1.0,
-    )
-
     def cluster_prompt(text: str):
         sentences = [
             s.strip()
@@ -153,7 +145,6 @@ if api_key:
                         embeddings,
                         labels,
                         title="Sentence clusters",
-                        perplexity=perplexity,
                     )
                 except ValueError as err:
                     st.warning(str(err))

--- a/test_clustering.py
+++ b/test_clustering.py
@@ -4,18 +4,10 @@ from matplotlib.figure import Figure
 from clustering import visualize_clusters
 
 
-def test_visualize_clusters_uses_pca_for_small_datasets():
-    """visualize_clusters should fall back to PCA when samples are ≤3."""
-    embeddings = np.array([[0.0, 0.0], [1.0, 1.0]])
-    labels = [0, 1]
-    fig = visualize_clusters(embeddings, labels)
-    assert isinstance(fig, Figure)
-    assert "PCA" in fig.axes[0].get_title()
-
-
-def test_visualize_clusters_clamps_perplexity():
-    """t-SNE perplexity is clamped to ``n_samples - 1`` when too large."""
+def test_visualize_clusters_uses_pca():
+    """visualize_clusters should always use PCA for dimensionality reduction."""
     embeddings = np.array([[float(i), float(i)] for i in range(5)])
     labels = [0, 1, 0, 1, 0]
     fig = visualize_clusters(embeddings, labels)
-    assert "perp=4.0" in fig.axes[0].get_title()
+    assert isinstance(fig, Figure)
+    assert "PCA" in fig.axes[0].get_title()


### PR DESCRIPTION
## Summary
- drop t-SNE reduction and rely exclusively on PCA for plotting
- remove perplexity control from Streamlit UI and update tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a99ff53d3883238c5f276864bc259c