### PR TITLE
Use RecursiveCharacterTextSplitter for prompt chunking

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ langchain-openai
 streamlit_js_eval
 scikit-learn
 matplotlib
+langchain-text-splitters


### PR DESCRIPTION
## Summary
- Chunk system prompts with RecursiveCharacterTextSplitter and cluster resulting embeddings
- Display clustered chunks in Streamlit app
- Add `langchain-text-splitters` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9a5814c7c8323b941bf857b9c6903