### PR TITLE
Add chunk similarity graph and chunk listing to Streamlit app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ streamlit_js_eval
 scikit-learn
 matplotlib
 langchain-text-splitters
+networkx

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -8,11 +8,17 @@ generated and displayed.
 
 import json
 import numpy as np
+import matplotlib.pyplot as plt
+import networkx as nx
 import streamlit as st
 from langchain_openai import OpenAIEmbeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from streamlit_js_eval import streamlit_js_eval
-from clustering import cluster_embeddings, visualize_clusters
+from clustering import (
+    cluster_embeddings,
+    visualize_clusters,
+    build_chunk_graph,
+)
 
 
 st.title("Hello, World!")
@@ -139,6 +145,17 @@ if api_key:
             except ValueError as err:
                 st.error(str(err))
             else:
+                st.subheader("Chunks")
+                for idx, chunk in enumerate(chunks):
+                    st.markdown(f"**Chunk {idx}**")
+                    st.write(chunk)
+
+                graph = build_chunk_graph(chunks, embeddings)
+                graph_fig, graph_ax = plt.subplots()
+                nx.draw_networkx(graph, ax=graph_ax, with_labels=True, node_size=500, font_size=8)
+                graph_ax.set_title("Chunk similarity graph")
+                st.pyplot(graph_fig)
+
                 try:
                     fig = visualize_clusters(
                         embeddings,

--- a/test_clustering.py
+++ b/test_clustering.py
@@ -1,7 +1,7 @@
 import numpy as np
 from matplotlib.figure import Figure
 
-from clustering import visualize_clusters
+from clustering import build_chunk_graph, visualize_clusters
 
 
 def test_visualize_clusters_uses_pca():
@@ -11,3 +11,13 @@ def test_visualize_clusters_uses_pca():
     fig = visualize_clusters(embeddings, labels)
     assert isinstance(fig, Figure)
     assert "PCA" in fig.axes[0].get_title()
+
+
+def test_build_chunk_graph_creates_edges_for_similar_chunks():
+    chunks = ["alpha", "alpha variant", "beta"]
+    embeddings = np.array([[1.0, 0.0], [0.9, 0.1], [0.0, 1.0]])
+    graph = build_chunk_graph(chunks, embeddings, threshold=0.85)
+    assert graph.number_of_nodes() == 3
+    # First two chunks are similar; third is different
+    assert graph.has_edge(0, 1)
+    assert not graph.has_edge(0, 2)


### PR DESCRIPTION
## Summary
- build cosine-similarity graph between text chunks
- display chunk list and similarity graph in Streamlit UI
- cover graph creation with unit test

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9ac03219c83238e3059e35a47f091