### PR TITLE
Add chunk weighting and display in Streamlit UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-hello
+## Metapi2 Demo
+
+This repository contains a small Streamlit application for experimenting with
+chunking and clustering text using OpenAI embeddings. The app can now also
+compute a **weight** for each chunk based on its cosine similarity to the
+average embedding. The weights are softmax‑normalized so they sum to one and
+allow you to see which parts of your prompt are most influential. The UI shows
+chunks ordered by weight and assembles a weighted prompt accordingly.

--- a/test_clustering.py
+++ b/test_clustering.py
@@ -1,7 +1,7 @@
 import numpy as np
 from matplotlib.figure import Figure
 
-from clustering import build_chunk_graph, visualize_clusters
+from clustering import build_chunk_graph, visualize_clusters, compute_chunk_weights
 
 
 def test_visualize_clusters_uses_pca():
@@ -21,3 +21,11 @@ def test_build_chunk_graph_creates_edges_for_similar_chunks():
     # First two chunks are similar; third is different
     assert graph.has_edge(0, 1)
     assert not graph.has_edge(0, 2)
+
+
+def test_compute_chunk_weights_emphasizes_similar_chunks():
+    embeddings = np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 0.0]])
+    reference = np.array([1.0, 0.0])
+    weights = compute_chunk_weights(embeddings, reference=reference)
+    assert np.isclose(weights.sum(), 1.0)
+    assert weights[0] == weights[2] > weights[1]


### PR DESCRIPTION
## Summary
- compute softmax-normalized chunk weights based on cosine similarity
- show chunk weights and assemble weighted prompt in Streamlit demo
- document and test the weighting helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9b6ca90248323862aa718db7522b3