### PR TITLE
Fix compute_chunk_weights import

### DIFF
--- a/clustering.py
+++ b/clustering.py
@@ -22,6 +22,16 @@ CLUSTERERS = {
     "dbscan": lambda _: DBSCAN(),
 }
 
+# Public API re-exported when ``from clustering import *`` is used. Including
+# ``compute_chunk_weights`` here fixes ``ImportError`` issues when that helper
+# function was missing from the module's exported namespace.
+__all__ = [
+    "cluster_embeddings",
+    "visualize_clusters",
+    "compute_chunk_weights",
+    "build_chunk_graph",
+]
+
 
 def cluster_embeddings(
     embeddings: np.ndarray,


### PR DESCRIPTION
## Summary
- Export clustering helpers via `__all__` to ensure `compute_chunk_weights` is accessible

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9bb7b3bb08323ac09f59dc0c96f93