### PR TITLE
Display cluster numbers on prompt chunk graph

### DIFF
--- a/clustering.py
+++ b/clustering.py
@@ -106,7 +106,10 @@ def visualize_clusters(
     method = "PCA"
 
     fig, ax = plt.subplots()
-    ax.scatter(Y[:, 0], Y[:, 1], s=40)
+    labels_arr = np.asarray(list(labels))
+    ax.scatter(Y[:, 0], Y[:, 1], c=labels_arr, cmap="tab10", s=40)
+    for (x, y), label in zip(Y, labels_arr):
+        ax.text(x, y, str(label), ha="center", va="center", fontsize=9)
     ax.set_title(f"{title} • {method}")
     ax.set_xlabel("dim 1")
     ax.set_ylabel("dim 2")

--- a/test_clustering.py
+++ b/test_clustering.py
@@ -13,6 +13,15 @@ def test_visualize_clusters_uses_pca():
     assert "PCA" in fig.axes[0].get_title()
 
 
+def test_visualize_clusters_labels_points_with_cluster_numbers():
+    embeddings = np.array([[float(i), float(i)] for i in range(3)])
+    labels = [0, 1, 2]
+    fig = visualize_clusters(embeddings, labels)
+    texts = [t.get_text() for t in fig.axes[0].texts]
+    assert len(texts) == len(labels)
+    assert set(texts) == {str(l) for l in labels}
+
+
 def test_build_chunk_graph_creates_edges_for_similar_chunks():
     chunks = ["alpha", "alpha variant", "beta"]
     embeddings = np.array([[1.0, 0.0], [0.9, 0.1], [0.0, 1.0]])


### PR DESCRIPTION
## Summary
- annotate each point in cluster visualization with its cluster number
- color-code scatter points by cluster label
- test added to ensure cluster numbers appear on chart

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9ec719c30832394c5ea03b962e992