### PR TITLE
Annotate PCA cluster points with chunk indices

### DIFF
--- a/clustering.py
+++ b/clustering.py
@@ -86,6 +86,11 @@ def visualize_clusters(
     -------
     matplotlib.figure.Figure
         The generated scatter plot.
+
+    Notes
+    -----
+    Points are colored according to their cluster label and annotated with
+    their chunk index to ease interpretation.
     """
     X = np.asarray(embeddings)
     n_samples = int(X.shape[0])
@@ -108,8 +113,9 @@ def visualize_clusters(
     fig, ax = plt.subplots()
     labels_arr = np.asarray(list(labels))
     ax.scatter(Y[:, 0], Y[:, 1], c=labels_arr, cmap="tab10", s=40)
-    for (x, y), label in zip(Y, labels_arr):
-        ax.text(x, y, str(label), ha="center", va="center", fontsize=9)
+    for idx, (x, y) in enumerate(Y):
+        # annotate each point with its chunk index above the marker
+        ax.text(x, y, str(idx), ha="center", va="bottom", fontsize=9)
     ax.set_title(f"{title} • {method}")
     ax.set_xlabel("dim 1")
     ax.set_ylabel("dim 2")

--- a/test_clustering.py
+++ b/test_clustering.py
@@ -13,13 +13,15 @@ def test_visualize_clusters_uses_pca():
     assert "PCA" in fig.axes[0].get_title()
 
 
-def test_visualize_clusters_labels_points_with_cluster_numbers():
+def test_visualize_clusters_labels_points_with_chunk_indices():
     embeddings = np.array([[float(i), float(i)] for i in range(3)])
-    labels = [0, 1, 2]
+    # deliberately give repeated cluster labels to ensure chunk indices are used
+    labels = [0, 0, 1]
     fig = visualize_clusters(embeddings, labels)
     texts = [t.get_text() for t in fig.axes[0].texts]
     assert len(texts) == len(labels)
-    assert set(texts) == {str(l) for l in labels}
+    # Expect the annotations to be the chunk indices 0,1,2 regardless of labels
+    assert set(texts) == {"0", "1", "2"}
 
 
 def test_build_chunk_graph_creates_edges_for_similar_chunks():


### PR DESCRIPTION
## Summary
- Label PCA scatter points with their chunk index instead of cluster number
- Document that each point is colored by cluster and annotated with its chunk id
- Adjust tests to validate chunk index annotations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9eff4c5588323927889e60a952786