### PR TITLE
Add XML parsing fallback for prompt chunking

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,8 @@ compute a **weight** for each chunk based on its cosine similarity to the
 average embedding. The weights are softmax‑normalized so they sum to one and
 allow you to see which parts of your prompt are most influential. The UI shows
 chunks ordered by weight and assembles a weighted prompt accordingly.
+
+By default the app attempts to parse the provided prompt as XML and clusters
+the textual content of the XML elements. If the input isn't valid XML it falls
+back to a plain text splitting strategy using LangChain's
+``RecursiveCharacterTextSplitter``.

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -7,6 +7,7 @@ generated and displayed.
 """
 
 import json
+import xml.etree.ElementTree as ET
 import numpy as np
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -125,10 +126,19 @@ if api_key:
         )
 
     def cluster_prompt(text: str):
-        splitter = RecursiveCharacterTextSplitter(
-            chunk_size=500, chunk_overlap=50
-        )
-        chunks = [doc.page_content for doc in splitter.create_documents([text])]
+        try:
+            root = ET.fromstring(text)
+        except ET.ParseError:
+            splitter = RecursiveCharacterTextSplitter(
+                chunk_size=500, chunk_overlap=50
+            )
+            chunks = [doc.page_content for doc in splitter.create_documents([text])]
+        else:
+            chunks = [
+                elem.text.strip()
+                for elem in root.iter()
+                if elem.text and elem.text.strip()
+            ]
         if len(chunks) < 2:
             raise ValueError("Need at least two chunks for clustering.")
         vectors = [embedder.embed_query(chunk) for chunk in chunks]


### PR DESCRIPTION
## Summary
- Parse prompts as XML when possible to cluster element text
- Fall back to LangChain `RecursiveCharacterTextSplitter` for non-XML input
- Document XML parsing behavior in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa1deccb28832393cfcebf9779b147