### PR TITLE
Add XML-aware prompt chunking

### DIFF
--- a/prompt_chunking.py
+++ b/prompt_chunking.py
@@ -1,0 +1,53 @@
+"""Utilities for splitting system prompts into smaller chunks.
+
+This module exposes a :func:`chunk_prompt` helper that first attempts to
+interpret the provided text as XML. When the text contains well-formed XML
+tags the content of each tag becomes an individual chunk. If the text either
+contains no tags or cannot be parsed as XML we fall back to LangChain's
+``RecursiveCharacterTextSplitter`` to create evenly sized chunks.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import List
+
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+
+def chunk_prompt(text: str) -> List[str]:
+    """Split ``text`` into a list of chunks.
+
+    The function prefers XML-based chunking when possible. It first checks if
+    the text appears to contain XML tags. If parsing succeeds, the textual
+    content of each element (in document order) is returned. When the text has
+    no tags or the XML is malformed we fall back to a ``RecursiveCharacter-
+    TextSplitter`` with a ``chunk_size`` of 500 characters and an overlap of
+    50 characters.
+
+    Parameters
+    ----------
+    text:
+        The raw system prompt text to split.
+
+    Returns
+    -------
+    list[str]
+        A list of extracted chunks. Whitespace-only chunks are omitted.
+    """
+
+    if "<" in text and ">" in text:
+        try:
+            root = ET.fromstring(text)
+        except ET.ParseError:
+            pass
+        else:
+            return [
+                elem.text.strip()
+                for elem in root.iter()
+                if elem.text and elem.text.strip()
+            ]
+
+    splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
+    return [doc.page_content for doc in splitter.create_documents([text])]
+

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -7,13 +7,11 @@ generated and displayed.
 """
 
 import json
-import xml.etree.ElementTree as ET
 import numpy as np
 import matplotlib.pyplot as plt
 import networkx as nx
 import streamlit as st
 from langchain_openai import OpenAIEmbeddings
-from langchain_text_splitters import RecursiveCharacterTextSplitter
 from streamlit_js_eval import streamlit_js_eval
 from clustering import (
     cluster_embeddings,
@@ -21,6 +19,7 @@ from clustering import (
     build_chunk_graph,
     compute_chunk_weights,
 )
+from prompt_chunking import chunk_prompt
 
 
 st.title("Hello, World!")
@@ -126,19 +125,7 @@ if api_key:
         )
 
     def cluster_prompt(text: str):
-        try:
-            root = ET.fromstring(text)
-        except ET.ParseError:
-            splitter = RecursiveCharacterTextSplitter(
-                chunk_size=500, chunk_overlap=50
-            )
-            chunks = [doc.page_content for doc in splitter.create_documents([text])]
-        else:
-            chunks = [
-                elem.text.strip()
-                for elem in root.iter()
-                if elem.text and elem.text.strip()
-            ]
+        chunks = chunk_prompt(text)
         if len(chunks) < 2:
             raise ValueError("Need at least two chunks for clustering.")
         vectors = [embedder.embed_query(chunk) for chunk in chunks]

--- a/test_prompt_chunking.py
+++ b/test_prompt_chunking.py
@@ -1,0 +1,18 @@
+"""Tests for the :mod:`prompt_chunking` module."""
+
+from prompt_chunking import chunk_prompt
+
+
+def test_chunk_prompt_splits_valid_xml():
+    text = "<root><a>Alpha</a><b>Beta</b></root>"
+    assert chunk_prompt(text) == ["Alpha", "Beta"]
+
+
+def test_chunk_prompt_falls_back_to_text_splitter_for_plain_text():
+    # Large text without any XML tags should be split by the text splitter.
+    text = "abc " * 200  # ~800 characters
+    chunks = chunk_prompt(text)
+    assert len(chunks) > 1
+    # Ensure the chunks combine (ignoring overlaps) to cover the original text
+    assert any("abc" in chunk for chunk in chunks)
+


### PR DESCRIPTION
## Summary
- add `chunk_prompt` utility that uses XML tags when present and falls back to RecursiveCharacterTextSplitter
- refactor Streamlit app to leverage new chunking logic
- cover chunking behavior with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa4091d7a88323af737d7903aeae9a