### PR TITLE
Support multiple top-level XML tags in prompt chunking

### DIFF
--- a/prompt_chunking.py
+++ b/prompt_chunking.py
@@ -37,16 +37,20 @@ def chunk_prompt(text: str) -> List[str]:
     """
 
     if "<" in text and ">" in text:
-        try:
-            root = ET.fromstring(text)
-        except ET.ParseError:
-            pass
-        else:
-            return [
-                elem.text.strip()
-                for elem in root.iter()
-                if elem.text and elem.text.strip()
-            ]
+        candidates = [(text, False), (f"<root>{text}</root>", True)]
+        for candidate, skip_root in candidates:
+            try:
+                root = ET.fromstring(candidate)
+            except ET.ParseError:
+                continue
+            else:
+                return [
+                    elem.text.strip()
+                    for elem in root.iter()
+                    if (not skip_root or elem is not root)
+                    and elem.text
+                    and elem.text.strip()
+                ]
 
     splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
     return [doc.page_content for doc in splitter.create_documents([text])]

--- a/test_prompt_chunking.py
+++ b/test_prompt_chunking.py
@@ -8,6 +8,13 @@ def test_chunk_prompt_splits_valid_xml():
     assert chunk_prompt(text) == ["Alpha", "Beta"]
 
 
+def test_chunk_prompt_handles_multiple_root_level_elements():
+    text = (
+        "<role>\nHey\n</role>\n<instructions>\nHey you\n</instructions>"
+    )
+    assert chunk_prompt(text) == ["Hey", "Hey you"]
+
+
 def test_chunk_prompt_falls_back_to_text_splitter_for_plain_text():
     # Large text without any XML tags should be split by the text splitter.
     text = "abc " * 200  # ~800 characters


### PR DESCRIPTION
## Summary
- handle prompts containing multiple top-level tags by wrapping with a synthetic root before XML parsing
- add regression test for multiple root-level tags

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa42b393d48323a63d9c4d475c70dc