### PR TITLE
Add geometric median-based prompt center computation

### DIFF
--- a/test_prompt_center.py
+++ b/test_prompt_center.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from clustering import geometric_median, compute_prompt_center
+
+
+def test_geometric_median_robust_to_outlier():
+    # Three identical points and one outlier in the opposite direction.
+    points = np.array([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0], [-1.0, 0.0]])
+    median = geometric_median(points)
+    assert np.allclose(median, np.array([1.0, 0.0]), atol=1e-3)
+
+
+def test_compute_prompt_center_returns_angles():
+    embeddings = np.array([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0], [-1.0, 0.0]])
+    center, radial = compute_prompt_center(embeddings)
+    # center should be unit norm and close to the majority direction
+    assert np.isclose(np.linalg.norm(center), 1.0)
+    assert np.allclose(center, np.array([1.0, 0.0]), atol=1e-3)
+    # three points aligned with center -> angle 0, outlier -> angle pi
+    assert radial.shape == (4,)
+    assert np.allclose(radial[:3], 0.0, atol=1e-6)
+    assert np.isclose(radial[3], np.pi, atol=1e-6)


### PR DESCRIPTION
## Summary
- add `geometric_median` helper implementing Weiszfeld's algorithm
- support prompt center extraction with angular distances via `compute_prompt_center`
- cover new helpers with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aab1d221108323b29d43ae274f5962