### PR TITLE
Add center-based chunk weighting option

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -124,6 +124,13 @@ if api_key:
             "Number of clusters", min_value=2, max_value=10, value=3
         )
 
+    weight_method = st.selectbox(
+        "Chunk weight method",
+        ["cosine", "center"],
+        index=0,
+        help="`cosine` weights by similarity to the centroid; `center` downweights outliers",
+    )
+
     def cluster_prompt(text: str):
         chunks = chunk_prompt(text)
         if len(chunks) < 2:
@@ -134,7 +141,7 @@ if api_key:
         if algorithm != "dbscan":
             k = min(k, len(embeddings))
         labels = cluster_embeddings(embeddings, algorithm=algorithm, n_clusters=k)
-        weights = compute_chunk_weights(embeddings)
+        weights = compute_chunk_weights(embeddings, method=weight_method)
         return chunks, embeddings, labels, weights
 
     if st.button("Analyze prompt"):
@@ -151,7 +158,9 @@ if api_key:
                         st.markdown(f"Weight: {weights[idx]:.3f}")
                         st.markdown(f"Cluster: {labels[idx]}")
 
-                st.subheader("Chunk weights (higher means more influence)")
+                st.subheader(
+                    f"Chunk weights • {weight_method} method (higher means more influence)"
+                )
                 sorted_idx = list(np.argsort(weights)[::-1])
                 for rank, idx in enumerate(sorted_idx):
                     st.markdown(

--- a/test_clustering.py
+++ b/test_clustering.py
@@ -48,6 +48,15 @@ def test_compute_chunk_weights_emphasizes_similar_chunks():
     assert weights[0] == weights[2] > weights[1]
 
 
+def test_compute_chunk_weights_center_downweights_outlier():
+    embeddings = np.array([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0], [-1.0, 0.0]])
+    weights = compute_chunk_weights(embeddings, method="center")
+    assert np.isclose(weights.sum(), 1.0)
+    # the outlier opposite to the center should receive the lowest weight
+    assert weights[3] < weights[0]
+    assert np.allclose(weights[:3], weights[0], atol=1e-6)
+
+
 def test_rank_chunks_pagerank_highlights_connected_nodes():
     chunks = ["alpha", "alpha variant", "beta"]
     embeddings = np.array([[1.0, 0.0], [0.9, 0.1], [0.0, 1.0]])


### PR DESCRIPTION
## Summary
- extend `compute_chunk_weights` with selectable `cosine` or `center` strategies
- expose new weighting option in Streamlit demo and label chosen method in results
- cover center-based weighting with unit test

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac4f24d9883238678ef33327d9087